### PR TITLE
Fix hero heading markup for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,13 +46,11 @@
     <!-- SEÇÃO HERO COM IMAGEM DE FUNDO -->
     <section class="hero" style="background-image: url('images/caminhodemoises01.png');">
       <div class="hero-content">
-        <h1>
-          <div style="display: flex; gap: 20px; font-size: 24px;">
+        <h1 class="hero-title" aria-label="Casa Pé na Areia">
           <span class="primary-text">C A S A</span>
           <span class="primary-text">P É</span>
           <span class="primary-text">N A</span>
           <span class="primary-text">A R E I A</span>
-        </div>
         </h1>
         <p>CAMINHO DE MOISÉS</p>
       </div>

--- a/style.css
+++ b/style.css
@@ -261,11 +261,18 @@ h1, h2, h3, h4, h5, h6 {
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
 }
 
+.hero-title {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  flex-wrap: wrap;
+  font-size: 24px;
+  margin-bottom: 25px;
+}
+
 .primary-text {
-  display: block;
+  display: inline-block;
   font-weight: 300;
-  font-size: 42px;
-  margin-bottom: 10px;
   color: var(--text-light);
 }
 


### PR DESCRIPTION
## Summary
- replace the nested div inside the hero heading with semantic markup and an accessible label
- move the layout styling for the hero title into CSS to maintain the horizontal presentation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e5ad81f4a08320a3c7b800465b962e